### PR TITLE
Fix go.mod broken issue

### DIFF
--- a/parser/go_mod.go
+++ b/parser/go_mod.go
@@ -25,8 +25,10 @@ func parseGoMod(path string, data []byte) ([]types.Dependency, error) {
 			PackageManager: types.PackageManagerGoMod,
 			Position: types.Position{
 				Line:      require.Syntax.Start.Line,
-				StartByte: require.Syntax.Start.Byte,
-				EndByte:   require.Syntax.End.Byte,
+				ColStart:  require.Syntax.Start.LineRune,
+				ColEnd:    require.Syntax.End.LineRune,
+				ByteStart: require.Syntax.Start.Byte,
+				ByteEnd:   require.Syntax.End.Byte,
 			},
 		})
 	}

--- a/parser/go_mod_test.go
+++ b/parser/go_mod_test.go
@@ -31,8 +31,10 @@ func TestParseGoMod(t *testing.T) {
 			PackageManager: "go-mod",
 			Position: types.Position{
 				Line:      6,
-				StartByte: 64,
-				EndByte:   111,
+				ColStart:  3,
+				ColEnd:    50,
+				ByteStart: 64,
+				ByteEnd:   111,
 			},
 		},
 		{
@@ -43,8 +45,10 @@ func TestParseGoMod(t *testing.T) {
 			PackageManager: "go-mod",
 			Position: types.Position{
 				Line:      7,
-				StartByte: 114,
-				EndByte:   144,
+				ColStart:  3,
+				ColEnd:    33,
+				ByteStart: 114,
+				ByteEnd:   144,
 			},
 		},
 		{
@@ -55,8 +59,10 @@ func TestParseGoMod(t *testing.T) {
 			PackageManager: "go-mod",
 			Position: types.Position{
 				Line:      8,
-				StartByte: 147,
-				EndByte:   181,
+				ColStart:  3,
+				ColEnd:    37,
+				ByteStart: 147,
+				ByteEnd:   181,
 			},
 		},
 		{
@@ -67,8 +73,10 @@ func TestParseGoMod(t *testing.T) {
 			PackageManager: "go-mod",
 			Position: types.Position{
 				Line:      12,
-				StartByte: 200,
-				EndByte:   233,
+				ColStart:  3,
+				ColEnd:    36,
+				ByteStart: 200,
+				ByteEnd:   233,
 			},
 		},
 	}

--- a/types/dependencies.go
+++ b/types/dependencies.go
@@ -12,8 +12,10 @@ type Dependency struct {
 
 type Position struct {
 	Line      int
-	StartByte int
-	EndByte   int
+	ColStart  int
+	ColEnd    int
+	ByteStart int
+	ByteEnd   int
 }
 
 type UpgradeInfo struct {


### PR DESCRIPTION
`go.mod` file is broken when there's multiple updates, because update position is determined by byte positions previously. Now, it's determined by line numbers to prevent this issue.